### PR TITLE
Save ArtParams by User

### DIFF
--- a/genArt2/backend/index.ts
+++ b/genArt2/backend/index.ts
@@ -1,70 +1,103 @@
 import express from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from '@clerk/clerk-sdk-node';
 import { PrismaClient } from '@prisma/client';
-import { createServer } from 'http';
 import cors from 'cors';
-import { saveUser } from './middleware/saveUser'; // Import the middleware
-import { requireAuth } from '@clerk/clerk-sdk-node'; // Ensure authentication
-import dotenv from 'dotenv';
-dotenv.config();
+import bodyParser from 'body-parser';
 
-const prisma = new PrismaClient();
 const app = express();
-const port = 3002;
+const prisma = new PrismaClient();
 
-app.use(cors());
+app.use(bodyParser.json());
 app.use(express.json());
 
-// Middleware to save user information
-app.use(saveUser);
+// Enable CORS for all routes
+app.use(cors({
+    origin: 'http://localhost:5173',
+    methods: 'GET,POST,PUT,DELETE',
+    allowedHeaders: 'Content-Type,Authorization'
+}));
 
-// Endpoint to fetch artists
-app.get('/artists', async (req, res) => {
-    try {
-        const artists = await prisma.user.findMany({
-            where: { isDeleted: false },
-            select: {
-                id: true,
-                name: true,
-                email: true,
-                clerkId: true,
-                createdAt: true,
-                updatedAt: true,
-                isDeleted: true,
-                avatarUrl: true,
-            },
-        });
-        res.status(200).json(artists);
-    } catch (error) {
-        res.status(500).json({ error: 'Failed to fetch artists' });
+// Clerk webhook to handle user creation
+app.post('/clerk-webhook', async (req, res) => {
+    const { type, data } = req.body;
+    console.log('Webhook received:', req.body); // Log the incoming request
+
+    if (type === 'user.created') {
+        const { id: clerkId, email_addresses, first_name, last_name, profile_image_url } = data;
+        const email = email_addresses[0]?.email_address;
+        const name = `${first_name} ${last_name}`;
+        const avatarUrl = profile_image_url;
+
+        if (!email) {
+            console.log('Email not provided in the webhook data'); // Log missing email
+            return res.status(400).json({ error: 'Email not provided' });
+        }
+
+        try {
+            console.log('Creating user in the database...');
+            const user = await prisma.user.create({
+                data: {
+                    clerkId,
+                    email,
+                    name,
+                    avatarUrl,
+                },
+            });
+            console.log('User created:', user); // Log the created user
+
+            return res.status(200).json({ message: 'User created successfully' });
+        } catch (error) {
+            console.error('Error creating user:', error); // Log the error
+            return res.status(500).json({ error: 'Failed to create user' });
+        }
     }
+
+    console.log('Unhandled event type:', type); // Log unhandled event type
+    res.status(200).json({ error: 'Unhandled event type' });
 });
 
 // Endpoint to save background color
-app.post('/backgrounds', requireAuth(), async (req, res) => {
+app.post('/backgrounds', requireAuth(async (req: Request, res: Response) => {
     console.log('Request received on /backgrounds');
+    console.log('Request headers:', req.headers);
+    console.log('Request body:', req.body);
+
     const { bgcolor } = req.body;
+    const creatorId = req.auth.userId;  // This should match the Clerk user ID
     console.log('Background color:', bgcolor);
+    console.log('Creator ID:', creatorId);
+
     try {
+        // Ensure the user exists
+        console.log('Checking if user exists in the database...');
+        const user = await prisma.user.findUnique({
+            where: { clerkId: creatorId }  // Use clerkId to find the user
+        });
+
+        if (!user) {
+            console.log('User not found in the database'); // Log user not found
+            return res.status(404).json({ error: 'User not found' });
+        }
+
+        console.log('Saving new art to the database...');
         const newArt = await prisma.art.create({
             data: {
                 bgcolor,
                 isPublished: true,
-                creatorId: req.user.id, // Use the user ID from the request
+                creatorId: user.id,  // Store the user's database ID
             },
         });
-        console.log('Art saved:', newArt);
+        console.log('Art saved:', newArt); // Log the created art
         res.status(200).json(newArt);
-    } catch (error) {
-        console.error('Error saving background:', error.message);
+    } catch (error: any) {
+        console.error('Error saving background:', error.message); // Log the error
         console.error(error.stack);
         res.status(500).json({ error: 'Failed to save background' });
     }
-});
+}));
 
-// Create an HTTP server with the Express app
-const server = createServer(app);
-
-// Start the server
-server.listen(port, () => {
-    console.log(`Server is running on http://localhost:${port}`);
+const PORT = process.env.PORT || 3002;
+app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/genArt2/backend/package-lock.json
+++ b/genArt2/backend/package-lock.json
@@ -41,6 +41,8 @@
     },
     "node_modules/@clerk/clerk-sdk-node": {
       "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-5.0.14.tgz",
+      "integrity": "sha512-HxcVn94rrVi/t4DKehFOZ3hDnlevurcZDa20cABgOBswbp6GFEsbQrnQJaR1kh+BsfWK/yX+WbuiiiHNhVetJA==",
       "license": "MIT",
       "dependencies": {
         "@clerk/backend": "1.3.0",

--- a/genArt2/backend/prisma/migrations/20240704190018_migration_string/migration.sql
+++ b/genArt2/backend/prisma/migrations/20240704190018_migration_string/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - The primary key for the `Art` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Art" DROP CONSTRAINT "Art_creatorId_fkey";
+
+-- AlterTable
+ALTER TABLE "Art" DROP CONSTRAINT "Art_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "creatorId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "Art_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "Art_id_seq";
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "User_id_seq";
+
+-- AddForeignKey
+ALTER TABLE "Art" ADD CONSTRAINT "Art_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/genArt2/backend/prisma/schema.prisma
+++ b/genArt2/backend/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model User {
-  id        Int     @id @default(autoincrement())
+  id        String     @id @default(cuid())
   name      String
   email     String  @unique
   clerkId   String  @unique
@@ -20,12 +20,12 @@ model User {
 }
 
 model Art {
-  id          Int      @id @default(autoincrement())
+  id          String     @id @default(cuid())
   bgcolor     String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   isPublished Boolean  @default(false)
   isDeleted   Boolean  @default(false)
-  creatorId   Int
+  creatorId   String
   creator     User     @relation(fields: [creatorId], references: [id])
 }

--- a/genArt2/frontend/src/api/artService.ts
+++ b/genArt2/frontend/src/api/artService.ts
@@ -1,16 +1,13 @@
-import { Art } from '@shared/types/models';
-
 const API_URL = 'http://localhost:3002'; // Define your backend API URL
 
-export const getArt = async (bgcolor: string, getToken: () => Promise<string | null>) => {
+export const getArt = async (bgcolor: string, token: string) => {
     try {
-        const response = await fetch(`${API_URL}/backgrounds`, {
+        const response = await fetch(`${API_URL}/backgrounds?bgcolor=${bgcolor}`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${await getToken()}`,
+                'Authorization': `Bearer ${token}`,
             },
-            body: JSON.stringify({ bgcolor }),
         });
 
         if (!response.ok) {
@@ -25,22 +22,35 @@ export const getArt = async (bgcolor: string, getToken: () => Promise<string | n
     }
 };
 
-export const saveArt = async (bgcolor: string, getToken: () => Promise<string | null>) => {
+export const saveArt = async (bgcolor: string, clerkId: string, token: string | null) => {
     try {
-        const response = await fetch(`${API_URL}/backgrounds`, {
+        console.log('Token obtained:', token);
+
+        const requestOptions = {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${await getToken()}`,
+                'Authorization': `Bearer ${token}`,
             },
-            body: JSON.stringify({ bgcolor }),
-        });
+            body: JSON.stringify({ bgcolor, creatorId: clerkId }),
+        };
+
+        console.log('Request options:', requestOptions);
+
+        const response = await fetch(`${API_URL}/backgrounds`, requestOptions);
+
+        console.log('Response status:', response.status);
+        console.log('Response headers:', response.headers);
 
         if (!response.ok) {
-            throw new Error('Failed to save art');
+            const errorText = await response.text();
+            console.error('Response error text:', errorText);
+            throw new Error(`Failed to save art: ${response.statusText}`);
         }
 
         const result = await response.json();
+        console.log('Response JSON:', result);
+
         return result;
     } catch (error) {
         console.error('Error saving art:', error);

--- a/genArt2/frontend/src/components/Backgrounds.tsx
+++ b/genArt2/frontend/src/components/Backgrounds.tsx
@@ -1,7 +1,8 @@
+// frontend/src/components/Backgrounds.tsx
+
 import React from 'react';
 import { useAuth, useUser } from '@clerk/clerk-react';
 import { saveArt } from '../api/artService';
-import { Art } from '@shared/types/models';
 
 const Backgrounds: React.FC = () => {
     const { isSignedIn, user } = useUser();
@@ -15,19 +16,40 @@ const Backgrounds: React.FC = () => {
         document.body.style.backgroundColor = randomColor;
     };
 
+
+
+
     const handleSave = async () => {
+        console.log('handleSave invoked');
+
         if (!user) {
             alert('You must be logged in to save art.');
             return;
         }
 
-        const backgroundColor = document.body.style.backgroundColor;
-        const result = await saveArt(backgroundColor, getToken);
+        const clerkId = user.id;
+        let backgroundColor = document.body.style.backgroundColor || '';
 
-        if (result) {
-            alert('Art saved successfully!');
-        } else {
-            alert('Failed to save art.');
+        if (backgroundColor === null) {
+            backgroundColor = '';
+        }
+
+        try {
+            const token = await getToken();
+            console.log('Clerk ID:', clerkId);
+            console.log('Token obtained:', token);
+            console.log('Background color:', backgroundColor);
+
+            const result = await saveArt(backgroundColor, clerkId, token);
+
+            if (result) {
+                alert('Art saved successfully!');
+            } else {
+                alert('Failed to save art.');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert('Failed to save art due to an error.');
         }
     };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d3a3ab3e3b37c42b170aeb045b47663690aff0a7  | 
|--------|--------|

### Summary:
Add functionality to save user-specific art parameters, including backend endpoints and frontend integration.

**Key points**:
- `genArt2/backend/index.ts`: Added endpoints for Clerk webhook to create users and save art with user association.
- `genArt2/backend/prisma/migrations/20240704190018_migration_string/migration.sql`: Updated `User` and `Art` tables to use `String` IDs.
- `genArt2/backend/prisma/schema.prisma`: Modified `User` and `Art` models to use `String` IDs.
- `genArt2/frontend/src/api/artService.ts`: Updated `saveArt` and `getArt` functions to include user-specific logic.
- `genArt2/frontend/src/components/Backgrounds.tsx`: Added UI logic to save art with user association.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->